### PR TITLE
temporary pawns should count as information exchange during brainstorming

### DIFF
--- a/ResearchReinvented/Source/OpportunityComps/ROComp_RequiresFaction.cs
+++ b/ResearchReinvented/Source/OpportunityComps/ROComp_RequiresFaction.cs
@@ -21,7 +21,7 @@ namespace PeteTimesSix.ResearchReinvented.OpportunityComps
         public override bool IsRare => false;
         public override bool IsFreebie => false;
         public override bool MetBy(Def def) => faction.def == def;
-        public override bool MetBy(Thing thing) => thing is Pawn pawn && MetByFaction(pawn.Faction);
+        public override bool MetBy(Thing thing) => thing is Pawn pawn && MetByFaction(pawn.GetExtraHomeFaction() ?? pawn.Faction);
         public bool MetByFaction(Faction faction) => faction == this.faction;
         public override bool IsValid => faction != null;
 

--- a/ResearchReinvented/Source/Rimworld/InteractionWorkers/InteractionWorker_Brainstorm.cs
+++ b/ResearchReinvented/Source/Rimworld/InteractionWorkers/InteractionWorker_Brainstorm.cs
@@ -30,7 +30,14 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.InteractionWorkers
             letterDef = null;
             lookTargets = null;
 
-            var opportunity = ResearchOpportunityManager.Instance.GetFirstFilteredOpportunity(OpportunityAvailability.Available, HandlingMode.Social, recipient);
+            ResearchOpportunity opportunity = null;
+            // First try to count this as faction information exchange.
+            if (opportunity == null && recipient.HasExtraHomeFaction())
+                opportunity = ResearchOpportunityManager.Instance.GetFirstFilteredOpportunity(OpportunityAvailability.Available, HandlingMode.Social, recipient);
+            if (opportunity == null && initiator.HasExtraHomeFaction())
+                opportunity = ResearchOpportunityManager.Instance.GetFirstFilteredOpportunity(OpportunityAvailability.Available, HandlingMode.Social, initiator);
+            if (opportunity == null)
+                opportunity = ResearchOpportunityManager.Instance.GetFirstFilteredOpportunity(OpportunityAvailability.Available, HandlingMode.Social, recipient);
                 //.GetCurrentlyAvailableOpportunities()
                 //.Where(o => o.def.handledBy.HasFlag(HandlingMode.Social) && o.requirement.MetBy(recipient))
                 //.FirstOrDefault();


### PR DESCRIPTION
Pawns like quest lodgers are internally considered to be part of the colony faction, but they are essentially from another faction, so they should be able to provide faction science info the same way e.g. visiting trade caravan members can.