### PR TITLE
Adjust AnalyseTerrain to facilitate external tie in for Life Lessons

### DIFF
--- a/ResearchReinvented/Source/Rimworld/JobDrivers/JobDriver_AnalyseTerrain.cs
+++ b/ResearchReinvented/Source/Rimworld/JobDrivers/JobDriver_AnalyseTerrain.cs
@@ -31,7 +31,7 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.JobDrivers
 
 		protected override IEnumerable<Toil> MakeNewToils()
         {
-			var opportunityAt = WorkGiver_AnalyseTerrain.FindOpportunityAt(pawn.Map, TargetCell);
+			var opportunityAt = WorkGiver_AnalyseTerrain.FindOpportunityAt(pawn.Map, TargetCell, pawn);
 			var opportunity = opportunityAt?.opportunity;
 
 			//ResearchOpportunity opportunity = ResearchOpportunityManager.instance.GetOpportunityForJob(this.job);

--- a/ResearchReinvented/Source/Rimworld/WorkGivers/WorkGiver_AnalyseTerrain.cs
+++ b/ResearchReinvented/Source/Rimworld/WorkGivers/WorkGiver_AnalyseTerrain.cs
@@ -82,7 +82,7 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
 				BuildCache();
 			}
 
-			var opportunity = FindOpportunityAt(pawn.Map, cell);
+			var opportunity = FindOpportunityAt(pawn.Map, cell, pawn);
 
 			if (opportunity == null)
 				return false;
@@ -124,7 +124,7 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
 
 		public override Job JobOnCell(Pawn pawn, IntVec3 cell, bool forced = false)
 		{
-			var opportunityAt = FindOpportunityAt(pawn.Map, cell);
+			var opportunityAt = FindOpportunityAt(pawn.Map, cell, pawn);
 
 			if (opportunityAt == null)
 			{
@@ -142,7 +142,7 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
 		{
 			var cell = target.Cell;
 
-            var opportunityAt = FindOpportunityAt(pawn.Map, cell);
+            var opportunityAt = FindOpportunityAt(pawn.Map, cell, pawn);
 
             if (opportunityAt == null)
             {
@@ -164,7 +164,7 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
 			return retVal;
 		}
 
-		public static (TerrainLayer type, ResearchOpportunity opportunity)? FindOpportunityAt(Map map, IntVec3 cell)
+		public static (TerrainLayer type, ResearchOpportunity opportunity)? FindOpportunityAt(Map map, IntVec3 cell, Pawn pawn)
 		{
 			{
 				var tempTerrainAt = map.terrainGrid.TempTerrainAt(map.cellIndices.CellToIndex(cell));


### PR DESCRIPTION
This pull request adds pawn as a parameter for WorkGiver_AnalyseTerrain.FindOpportunityAt()
The goal of this is to facilitate my own tie in for Life Lessons, where I patch the HasJobOn and JobOn methods to filter opportunities based on whether the pawn is "qualified" per my mod's own definition. With the recent update for new terrain types, the resolution of the OpportunityCache was extracted to a separate method that no longer has context to the pawn being checked; which, to my knowledge, makes it impossible for me to handle the patch as I currently do.

This is the minimal code change needed for me to accomplish what I need to do. I did however consider setting up a separate method such as FilterCacheFor() that would be called for each terrain type, allowing me to use a prefix or postfix patch as opposed to a rather fragile transpiler. If you have a preference for implementation, I'd be happy to adjust the change.