### PR TITLE
Add filter methods to workgivers to allow for external tie in before resolving final opportunity

### DIFF
--- a/ResearchReinvented/Source/Rimworld/JobDrivers/JobDriver_AnalyseTerrain.cs
+++ b/ResearchReinvented/Source/Rimworld/JobDrivers/JobDriver_AnalyseTerrain.cs
@@ -31,7 +31,7 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.JobDrivers
 
 		protected override IEnumerable<Toil> MakeNewToils()
         {
-			var opportunityAt = WorkGiver_AnalyseTerrain.FindOpportunityAt(pawn.Map, TargetCell);
+			var opportunityAt = WorkGiver_AnalyseTerrain.FindOpportunityAt(pawn, TargetCell);
 			var opportunity = opportunityAt?.opportunity;
 
 			//ResearchOpportunity opportunity = ResearchOpportunityManager.instance.GetOpportunityForJob(this.job);

--- a/ResearchReinvented/Source/Rimworld/WorkGivers/WorkGiver_Analyse.cs
+++ b/ResearchReinvented/Source/Rimworld/WorkGivers/WorkGiver_Analyse.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Verse;
@@ -72,9 +73,9 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
             if (!pawn.CanReserve(t, 1, -1, null, forced))
                 return false;
 
-            var thingDef = MinifyUtility.GetInnerIfMinified(t).def;
+            Thing actualThing = MinifyUtility.GetInnerIfMinified(t);
 
-			var opportunity = OpportunityCache[thingDef].FirstOrDefault();
+			var opportunity = FilterCacheFor(actualThing, pawn).FirstOrDefault();
 			if (PrototypeKeeper.Instance.IsPrototype(t) &&  opportunity.relation != ResearchRelation.Ancestor)
             {
                 JobFailReason.Is(StringsCache.JobFail_IsPrototype, null);
@@ -99,15 +100,15 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
         {
             var researchBench = GetBestResearchBench(pawn);
 
-			var thingDef = MinifyUtility.GetInnerIfMinified(t).def;
+			Thing actualThing = MinifyUtility.GetInnerIfMinified(t);
 
-			if(!OpportunityCache.ContainsKey(thingDef)) 
+			if(!OpportunityCache.ContainsKey(actualThing.def)) 
 			{
-				Log.Warning($"opportunity cache did not contain {thingDef} for thing {t}");
+				Log.Warning($"opportunity cache did not contain {actualThing.def} for thing {t}");
 				return null;
 			}
 
-			var opportunity = OpportunityCache[thingDef].First();
+			var opportunity = FilterCacheFor(actualThing, pawn).First();
 
 			JobDef jobDef = opportunity.JobDefs.First(j => j.driverClass == DriverClass);
 			Job job = JobMaker.MakeJob(jobDef, t, expiryInterval: 20000, checkOverrideOnExpiry: true);
@@ -246,5 +247,11 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
 			cacheBuiltOnTick = Find.TickManager.TicksAbs;
 		}
 
-	}
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static HashSet<ResearchOpportunity> FilterCacheFor(Thing thing, Pawn pawn)
+        {
+            return OpportunityCache[thing.def];
+        }
+
+    }
 }

--- a/ResearchReinvented/Source/Rimworld/WorkGivers/WorkGiver_AnalyseInPlace.cs
+++ b/ResearchReinvented/Source/Rimworld/WorkGivers/WorkGiver_AnalyseInPlace.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Verse;
@@ -78,7 +79,7 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
             if (!pawn.CanReserve(thing, 1, -1, null, forced))
                 return false;
 
-            var opportunity = OpportunityCache[thing.def].FirstOrDefault();
+            var opportunity = FilterCacheFor(thing, pawn).FirstOrDefault();
             if (PrototypeKeeper.Instance.IsPrototype(thing) && opportunity.relation != ResearchRelation.Ancestor)
             {
                 JobFailReason.Is(StringsCache.JobFail_IsPrototype, null);
@@ -106,9 +107,9 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
             return new HistoryEvent(HistoryEventDefOf.Researching, pawn.Named(HistoryEventArgsNames.Doer)).Notify_PawnAboutToDo_Job();
         }
 
-		public override Job JobOnThing(Pawn pawn, Thing thing, bool forced = false)
+        public override Job JobOnThing(Pawn pawn, Thing thing, bool forced = false)
 		{
-			var opportunity = OpportunityCache[thing.def].First();
+			var opportunity = FilterCacheFor(thing, pawn).First();
 
 			var jobDef = opportunity.JobDefs.First(j => j.driverClass == DriverClass);
 			Job job = JobMaker.MakeJob(jobDef, thing, expiryInterval: 1500, checkOverrideOnExpiry: true);
@@ -197,5 +198,11 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.WorkGivers
 
             cacheBuiltOnTick = Find.TickManager.TicksAbs;
 		}
-	}
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static HashSet<ResearchOpportunity> FilterCacheFor(Thing thing, Pawn pawn)
+        {
+            return OpportunityCache[thing.def];
+        }
+    }
 }


### PR DESCRIPTION
Alternative solution for #27
This pull request adds a FilterCacheFor method to 3 workgivers that use a dictionary to handle cached opportunities. I have passed in Thing and Pawn where possible and resolve the actual dict key within this method to hopefully minimize the chance that the method gets inlined. Not sure how much one extra field would matter to the JIT.

The goal of this is to facilitate my own tie in for Life Lessons, where I patch the HasJobOn and JobOn methods to filter opportunities based on whether the pawn is "qualified" per my mod's own definition. With the recent update for new terrain types, the resolution of the OpportunityCache was extracted to a separate method that no longer has context to the pawn being checked; which, to my knowledge, makes it impossible for me to handle the patch as I currently do.

This solution adds a new method separating the cache from the caller by one extra layer, which allows me or other modders to use a postfix patch to modify the returned collection rather than using fragile transpilers.