### PR TITLE
make it easier for research jobs to be stopped/replaced by others

### DIFF
--- a/ResearchReinvented/Source/Rimworld/JobDrivers/JobDriver_Analyse.cs
+++ b/ResearchReinvented/Source/Rimworld/JobDrivers/JobDriver_Analyse.cs
@@ -114,8 +114,8 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.JobDrivers
                 }
                 return opportunity.ProgressFraction;
             }, false, -0.5f);
-            research.defaultCompleteMode = ToilCompleteMode.Never;
-            //research.defaultDuration = JobEndInterval;
+            research.defaultCompleteMode = ToilCompleteMode.Delay;
+            research.defaultDuration = JobEndInterval;
             research.activeSkill = (() => SkillDefOf.Intellectual);
             yield return research;
             yield return Toils_Jump.JumpIf(research, () => !opportunity.IsFinished);

--- a/ResearchReinvented/Source/Rimworld/JobDrivers/JobDriver_ResearchRR.cs
+++ b/ResearchReinvented/Source/Rimworld/JobDrivers/JobDriver_ResearchRR.cs
@@ -83,7 +83,8 @@ namespace PeteTimesSix.ResearchReinvented.Rimworld.JobDrivers
 			research.AddEndCondition(() => opportunity.IsFinished || opportunity.CurrentAvailability != OpportunityAvailability.Available ? JobCondition.Succeeded : JobCondition.Ongoing);
 			research.WithEffect(EffecterDefOf.Research, ResearchBenchIndex);
 			research.AddFailCondition(() => !ResearchBench.CanUseNow());
-			research.defaultCompleteMode = ToilCompleteMode.Never;
+			research.defaultCompleteMode = ToilCompleteMode.Delay;
+			research.defaultDuration = 4000;
 			research.FailOnCannotTouch(TargetIndex.A, PathEndMode.InteractionCell);
 			research.activeSkill = (() => SkillDefOf.Intellectual);
 			yield return research;


### PR DESCRIPTION
It seems to me that my research pawn spends too much time researching, either until getting very hungry/tired, or keep researching while there are other jobs to do. This patch makes the mod's research jobs use the same complete mod as the vanilla one. I'm not quite sure why "eternal" complete mode is used, especially given the commented out code referencing the vanilla mode, I have not so far noticed any problem after my change (if the duration runs out and there's nothing else to do, the pawn will simply start another job for a new duration).


