### PR TITLE
improve faction requirement matching

### DIFF
--- a/ResearchReinvented/Source/OpportunityComps/ROComp_RequiresFaction.cs
+++ b/ResearchReinvented/Source/OpportunityComps/ROComp_RequiresFaction.cs
@@ -21,7 +21,7 @@ namespace PeteTimesSix.ResearchReinvented.OpportunityComps
         public override bool IsRare => false;
         public override bool IsFreebie => false;
         public override bool MetBy(Def def) => faction.def == def;
-        public override bool MetBy(Thing thing) => thing is Pawn pawn && MetByFaction(pawn.GetExtraHomeFaction() ?? pawn.Faction);
+        public override bool MetBy(Thing thing) => thing is Pawn pawn && MetByFaction(pawn.HomeFaction);
         public bool MetByFaction(Faction faction) => faction == this.faction;
         public override bool IsValid => faction != null;
 

--- a/ResearchReinvented/Source/OpportunityComps/ROComp_RequiresFactionlessPawn.cs
+++ b/ResearchReinvented/Source/OpportunityComps/ROComp_RequiresFactionlessPawn.cs
@@ -19,7 +19,7 @@ namespace PeteTimesSix.ResearchReinvented.OpportunityComps
         public override bool IsRare => false;
         public override bool IsFreebie => false;
         public override bool MetBy(Def def) => false;
-        public override bool MetBy(Thing thing) => thing is Pawn pawn && (pawn.Faction == null || pawn.Faction.temporary);
+        public override bool MetBy(Thing thing) => thing is Pawn pawn && (pawn.HomeFaction == null || pawn.HomeFaction.temporary);
         public override bool IsValid => true;
 
         public ROComp_RequiresFactionlessPawn()


### PR DESCRIPTION
Pawn.HomeFaction returns the original faction if present, so this makes slaves provide knowledge of their original faction, and pawns from mini factions count as outsiders when they are temporary quest lodgers.

This is what #25 should have been.
